### PR TITLE
Fixed twig template error with RC1

### DIFF
--- a/src/templates/_components/fields/Position_settings.twig
+++ b/src/templates/_components/fields/Position_settings.twig
@@ -24,7 +24,7 @@
             <tr>
                 <td>
                     {{ forms.lightswitch({
-                        on: settings.options[option],
+                        on: settings.options[option]|default(false),
                         small: true,
                         name: 'options['~option~']'
                     }) }}


### PR DESCRIPTION
Twig would throw an error when creating / editing fields, added default setting for lightswitch