### PR TITLE
Use new package-name in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To install the plugin, follow these instructions.
 
 2. Then tell Composer to load the plugin:
 
-        composer require rias/craft3-position-fieldtype
+        composer require rias/craft-position-fieldtype
 
 3. In the Control Panel, go to Settings → Plugins and click the “Install” button for Position Fieldtype.
 


### PR DESCRIPTION
The package-name was changed with version 1.0.4, but the documentation hasn't been updated yet.

If you install the plugin with the line given by the Readme, composer tells you:

```
$ composer require rias/craft3-position-fieldtype
Using version ^1.0 for rias/craft3-position-fieldtype
[...]
Package operations: 1 install, 0 updates, 0 removals
  - Installing rias/craft3-position-fieldtype (1.0.3): Downloading (100%)         
Package rias/craft3-position-fieldtype is abandoned, you should avoid using it. Use rias/craft-position-fieldtype instead.
[...]
```