### PR TITLE
Check for empty strings on saving the position field settings

### DIFF
--- a/src/fields/Position.php
+++ b/src/fields/Position.php
@@ -109,7 +109,7 @@ class Position extends Field
                 $this->addError($attribute, Craft::t('position-fieldtype', 'Invalid key in $options'));
             }
 
-            if ($value != 0 && $value != 1) {
+            if ($value != 0 && $value != 1 && $value != '') {
                 $this->addError($attribute, Craft::t('position-fieldtype', 'Invalid value for $options[{key}].', [
                     '{key}' => $key,
                 ]));


### PR DESCRIPTION
When the position field is used in a Matrix block setting, the `options` attribute receives `"1"` or `""` as the values for the options (left, right, center, etc). Until PHP 7.*, loosely comparing `""` to `0` returned `true`. As of PHP 8, the same comparison returns `false` (see https://www.php.net/manual/en/migration80.incompatible.php). The proposed change adds empty strings as a valid value for any of the `options`.